### PR TITLE
Add macro for disabling replacing Windows API calls with UTF8 versions

### DIFF
--- a/include/utf8/utf8.h
+++ b/include/utf8/utf8.h
@@ -818,7 +818,7 @@ bool operator !=(const exception& lhs, const exception& rhs)
 
 }; //namespace utf8
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(REPLACE_WIN32_APIS_UTF8)
 #include <utf8/winutf8.h>
 #endif
 #include <utf8/ini.h>

--- a/include/utf8/utf8.h
+++ b/include/utf8/utf8.h
@@ -818,7 +818,7 @@ bool operator !=(const exception& lhs, const exception& rhs)
 
 }; //namespace utf8
 
-#if defined(_WIN32) && !defined(NO_REPLACE_WIN32_APIS_UTF8)
+#if defined(_WIN32) && !defined(UTF8_KEEP_WIN32_API)
 #include <utf8/winutf8.h>
 #endif
 #include <utf8/ini.h>

--- a/include/utf8/utf8.h
+++ b/include/utf8/utf8.h
@@ -818,7 +818,7 @@ bool operator !=(const exception& lhs, const exception& rhs)
 
 }; //namespace utf8
 
-#if defined(_WIN32) && !defined(REPLACE_WIN32_APIS_UTF8)
+#if defined(_WIN32) && !defined(NO_REPLACE_WIN32_APIS_UTF8)
 #include <utf8/winutf8.h>
 #endif
 #include <utf8/ini.h>


### PR DESCRIPTION
By default, `utf8` replaces Windows API function calls with its UTF8 versions when the header is imported, by defining `REPLACE_WIN32_APIS_UTF8` `utf8` would not attempt to `undef` the Windows API calls 